### PR TITLE
retargeting checks to big problem yaml

### DIFF
--- a/.github/workflows/new_problem_check.yml
+++ b/.github/workflows/new_problem_check.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
     paths:
-      - "utils/new_problem.yaml"
+      - "problems.yaml"
   pull_request:
     paths:
-      - "utils/new_problem.yaml"
+      - "problems.yaml"
   workflow_dispatch: # allow triggering workflow manually
     inputs:
       reason:
@@ -34,7 +34,6 @@ jobs:
           pip install -r utils/requirements.txt
 
       - name: Run New Problem Check
-        if: ${{ hashFiles('utils/new_problem.yaml') != '' }}
         run: |
-          python utils/validate_yaml.py utils/new_problem.yaml
+          python utils/validate_yaml.py problems.yaml
 

--- a/utils/validate_yaml.py
+++ b/utils/validate_yaml.py
@@ -14,7 +14,6 @@ OPTIONAL_FIELDS = ["multimodal"]
 UNIQUE_FIELDS = ["name"]
 NON_EMPTY_FIELDS = ["name"]
 UNIQUE_WARNING_FIELDS = ["reference", "implementation"]
-PROBLEMS_FILE = "problems.yaml"
 
 
 def read_data(filepath):
@@ -80,19 +79,13 @@ def check_fields(data):
     return True
 
 
-def check_novelty(data):
-    # Load existing problems
-    read_status, existing_data = read_data(PROBLEMS_FILE)
-    if read_status != 0:
-        print("::error::Could not read existing problems for novelty check.")
-        return False
-    assert existing_data is not None
+def check_novelty(data, checked_data):
     for field in UNIQUE_FIELDS + UNIQUE_WARNING_FIELDS:
         # skip empty fields
         if not data.get(field):
             continue
         existing_values = {
-            entry.get(field) for entry in existing_data if isinstance(entry, dict)
+            entry.get(field) for entry in checked_data if isinstance(entry, dict)
         }
         if data.get(field) in existing_values:
             if field in UNIQUE_WARNING_FIELDS:
@@ -116,11 +109,14 @@ def validate_yaml(filepath):
         sys.exit(1)
     assert data is not None
 
+    checked_data = []
+
     for i, new_data in enumerate(data):  # Iterate through each top-level entry
         # Check required and unique fields
-        if not check_fields(new_data) or not check_novelty(new_data):
+        if not check_fields(new_data) or not check_novelty(new_data, checked_data):
             print(f"::error::Validation failed for entry {i+1}.")
             sys.exit(1)
+        checked_data.append(new_data)  # Add to checked data for novelty checks
 
     # YAML is valid if we reach this point
     print("YAML syntax is valid.")


### PR DESCRIPTION
This pull request updates the workflow and validation logic for checking new problems in the repository. The main focus is on simplifying the workflow to operate directly on `problems.yaml` instead of `utils/new_problem.yaml`, and improving how uniqueness and novelty checks are performed during YAML validation.

**Workflow and validation improvements:**

* Updated the GitHub Actions workflow (`.github/workflows/new_problem_check.yml`) to trigger on changes to `problems.yaml` instead of `utils/new_problem.yaml`, and to validate `problems.yaml` directly. [[1]](diffhunk://#diff-e2a466e571cb681c685d9bdb4df91f1d84affe3ec8049e9b3b01c168a9e2d71cL8-R11) [[2]](diffhunk://#diff-e2a466e571cb681c685d9bdb4df91f1d84affe3ec8049e9b3b01c168a9e2d71cL37-R38)
* Refactored the novelty check in `utils/validate_yaml.py` to perform uniqueness checks incrementally against already validated entries in the same `problems.yaml` file, removing reliance on a global `PROBLEMS_FILE` constant. [[1]](diffhunk://#diff-53a24b971b3e33b7f3d375b11a4452a78c8f71e34437d5c8b1999c080a8038a2L83-R88) [[2]](diffhunk://#diff-53a24b971b3e33b7f3d375b11a4452a78c8f71e34437d5c8b1999c080a8038a2L17)
* Modified the validation loop in `validate_yaml` to accumulate checked entries and use them for novelty checks, ensuring entries are validated in sequence and uniqueness is enforced within the file.