### PR TITLE
wrap yaml into main to avoid it auto-running on validate through the import

### DIFF
--- a/yaml_to_html.py
+++ b/yaml_to_html.py
@@ -89,6 +89,6 @@ if __name__ == "__main__":
 
     # Merge table and scripts into HTML page
     with open(html_index, "wb") as output_file:
-        for in_file in [html_header, html_table, html_scripts, html_footer]:
-            with open(in_file, "rb") as in_file:
-                shutil.copyfileobj(in_file, output_file)
+        for path in [html_header, html_table, html_scripts, html_footer]:
+            with open(path, "rb") as src:
+                shutil.copyfileobj(src, output_file)

--- a/yaml_to_html.py
+++ b/yaml_to_html.py
@@ -51,34 +51,34 @@ default_columns = ["name",
                    "reference",
                    "implementation"]
 
-# Load data
-with open(yaml_file) as yaml_input:
-    data = pd.json_normalize(yaml.safe_load(yaml_input))
-
-
 if __name__ == "__main__":
-  if all_columns is False:
+    # Load data
+    with open(yaml_file) as yaml_input:
+      data = pd.json_normalize(yaml.safe_load(yaml_input))
+    
+    
+    if all_columns is False:
       columns = default_columns
       data = data[columns]
-
-  data = data.map(linkify_cell)
-
-  # Generate plain table
-  table = data.to_html(render_links=False,
+    
+    data = data.map(linkify_cell)
+    
+    # Generate plain table
+    table = data.to_html(render_links=False,
                        escape=False,  # Don't escape HTML in cells (to allow links)
                        index=False,
                        table_id="problems",
                        classes=["display compact", "display", "styled-table"],  # Set display style
                        border=0,
                        na_rep="")  # Leave NaN cells empty
-
-  # Add footer to facilitate individual column search
-  idx = table.index('</table>')
-  final_table = table[:idx] + "<tfoot><tr>" + " ".join(["<th>"+ i +"</th>" for i in data.columns])+"</tr> </tfoot>" + table[idx:]
-
-  default_hidden_columns = {"textual description", "reference", "implementation"}
-
-  column_toggles = "".join(
+    
+    # Add footer to facilitate individual column search
+    idx = table.index('</table>')
+    final_table = table[:idx] + "<tfoot><tr>" + " ".join(["<th>"+ i +"</th>" for i in data.columns])+"</tr> </tfoot>" + table[idx:]
+    
+    default_hidden_columns = {"textual description", "reference", "implementation"}
+    
+    column_toggles = "".join(
       [
           (
               f'<label class="column-chip">'
@@ -89,23 +89,23 @@ if __name__ == "__main__":
           )
           for i, col in enumerate(data.columns)
       ]
-  )
-
-  with open(html_table_template, encoding="utf-8") as template_file:
+    )
+    
+    with open(html_table_template, encoding="utf-8") as template_file:
       table_template = template_file.read()
-
-  table_markup = (
+    
+    table_markup = (
       table_template
       .replace("__COLUMN_TOGGLES__", column_toggles)
       .replace("__TABLE__", final_table)
-  )
-
-  # Write table to file
-  with open(html_table, "w", encoding="utf-8") as table_file:
+    )
+    
+    # Write table to file
+    with open(html_table, "w", encoding="utf-8") as table_file:
       table_file.write(table_markup)
-
-  # Merge table and scripts into HTML page
-  with open(html_index, "wb") as output_file:
+    
+    # Merge table and scripts into HTML page
+    with open(html_index, "wb") as output_file:
       for part_path in [html_header, html_table, html_scripts, html_footer]:
           with open(part_path, "rb") as part_file:
               shutil.copyfileobj(part_file, output_file)

--- a/yaml_to_html.py
+++ b/yaml_to_html.py
@@ -15,10 +15,13 @@ def linkify_cell(value):
 
     def repl(m):
         url = m.group(1)
-        href = url if url.lower().startswith(("http://", "https://")) else f"https://{url}"
+        href = (
+            url if url.lower().startswith(("http://", "https://")) else f"https://{url}"
+        )
         return f'<a href="{href}">{url}</a>'
 
     return URL_RE.sub(repl, value)
+
 
 yaml_file = "problems.yaml"
 
@@ -29,51 +32,63 @@ html_scripts = f"{html_dir}javascript.html"
 html_footer = f"{html_dir}footer.html"
 html_index = f"{html_dir}index.html"
 
-# Load data
-with open(yaml_file) as in_file:
-    data = pd.json_normalize(yaml.safe_load(in_file))
+default_columns = [
+    "name",
+    "textual description",
+    "suite/generator/single",
+    "objectives",
+    "dimensionality",
+    "variable type",
+    "constraints",
+    "dynamic",
+    "noise",
+    "multi-fidelity",
+    "source (real-world/artificial)",
+    "reference",
+    "implementation",
+]
 
-# Choose desired columns
-all_columns = False
-default_columns = ["name",
-                   "textual description",
-                   "suite/generator/single",
-                   "objectives",
-                   "dimensionality",
-                   "variable type",
-                   "constraints",
-                   "dynamic",
-                   "noise",
-                   "multi-fidelity",
-                   "source (real-world/artificial)",
-                   "reference",
-                   "implementation"]
+if __name__ == "__main__":
+    # Load data
+    with open(yaml_file) as in_file:
+        data = pd.json_normalize(yaml.safe_load(in_file))
 
-if all_columns is False:
-    columns = default_columns
-    data = data[columns]
+    # Choose desired columns
+    all_columns = False
 
-data = data.map(linkify_cell)
+    if all_columns is False:
+        columns = default_columns
+        data = data[columns]
 
-# Generate plain table
-table = data.to_html(render_links=False,
-                     escape=False,  # Don't escape HTML in cells (to allow links)
-                     index=False,
-                     table_id="problems",
-                     classes=["display compact", "display", "styled-table"],  # Set display style
-                     border=0,
-                     na_rep="")  # Leave NaN cells empty
+    data = data.map(linkify_cell)
 
-# Add footer to facilitate individual column search
-idx = table.index('</table>')
-final_table = table[:idx] + "<tfoot><tr>" + " ".join(["<th>"+ i +"</th>" for i in data.columns])+"</tr> </tfoot>" + table[idx:]
+    # Generate plain table
+    table = data.to_html(
+        render_links=False,
+        escape=False,  # Don't escape HTML in cells (to allow links)
+        index=False,
+        table_id="problems",
+        classes=["display compact", "display", "styled-table"],  # Set display style
+        border=0,
+        na_rep="",
+    )  # Leave NaN cells empty
 
-# Write table to file
-with open(html_table, "w") as table_file:
-    table_file.write(final_table)
+    # Add footer to facilitate individual column search
+    idx = table.index("</table>")
+    final_table = (
+        table[:idx]
+        + "<tfoot><tr>"
+        + " ".join(["<th>" + i + "</th>" for i in data.columns])
+        + "</tr> </tfoot>"
+        + table[idx:]
+    )
 
-# Merge table and scripts into HTML page
-with open(html_index, "wb") as output_file:
-    for in_file in [html_header, html_table, html_scripts, html_footer]:
-        with open(in_file, "rb") as in_file:
-            shutil.copyfileobj(in_file, output_file)
+    # Write table to file
+    with open(html_table, "w") as table_file:
+        table_file.write(final_table)
+
+    # Merge table and scripts into HTML page
+    with open(html_index, "wb") as output_file:
+        for in_file in [html_header, html_table, html_scripts, html_footer]:
+            with open(in_file, "rb") as in_file:
+                shutil.copyfileobj(in_file, output_file)


### PR DESCRIPTION
This pull request refactors the `yaml_to_html.py` script to improve code structure, readability, and maintainability. The main changes involve moving data loading and processing into a `__main__` guard, reformatting code for clarity, and making minor improvements to table generation.

**Code organization and structure:**
* Moved the main script logic (data loading, column selection, and table generation) under the `if __name__ == "__main__":` block to prevent accidental execution when the module is imported.
* Reformatted code for better readability, including consistent indentation and line breaks, especially in the `linkify_cell` function and table generation. [[1]](diffhunk://#diff-fd5bbd6296242225f8ac60f2c83f156deea326aa97f8f3c7176403364c77504aL18-R25) [[2]](diffhunk://#diff-fd5bbd6296242225f8ac60f2c83f156deea326aa97f8f3c7176403364c77504aL59-R84)

**Data loading and processing:**
* Relocated the data loading and column selection logic into the main guard, making the script's execution flow clearer and more modular. [[1]](diffhunk://#diff-fd5bbd6296242225f8ac60f2c83f156deea326aa97f8f3c7176403364c77504aL32-R36) [[2]](diffhunk://#diff-fd5bbd6296242225f8ac60f2c83f156deea326aa97f8f3c7176403364c77504aL50-R57)
