### PR TITLE
feat: Make YAML serialization deterministic

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>BSO-toolbox</td>
       <td>C++</td>
-      <td>{'40 seconds', '1 second'}</td>
+      <td>{'1 second', '40 seconds'}</td>
       <td><a href="https://github.com/TUe-excellent-buildings/BSO-toolbox">https://github.com/TUe-excellent-buildings/BSO-toolbox</a></td>
       <td>Building Spatial Design toolbox (TU/e)</td>
       <td></td>
@@ -214,7 +214,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>26</td>
       <td>1</td>
       <td>noisy</td>
-      <td>box | unknown</td>
+      <td>unknown | box</td>
       <td>>=14</td>
       <td></td>
       <td>noisy</td>
@@ -767,11 +767,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHGNBG | GNBG-II</td>
+      <td>GNBG-II | IOHGNBG</td>
       <td></td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a> | <a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a></td>
-      <td>IOHprofiler version of GNBG | Generalized Numerical Benchmark Generator version 2</td>
+      <td><a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a> | <a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a></td>
+      <td>Generalized Numerical Benchmark Generator version 2 | IOHprofiler version of GNBG</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1194,7 +1194,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_amvop</td>
       <td>AMVOP</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>integer | categorical | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1317,7 +1317,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_bbob_biobj_mixint</td>
       <td>BBOB-biobj-mixint</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>10-320</td>
       <td>2</td>
       <td></td>
@@ -1440,7 +1440,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_bbob_mixint</td>
       <td>BBOB-mixint</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>10-320</td>
       <td>1</td>
       <td></td>
@@ -1710,11 +1710,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>CEC2013 reference code | IOHexperimenter</td>
+      <td>IOHexperimenter | CEC2013 reference code</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
-      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
+      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a></td>
+      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1876,7 +1876,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>CFD test problem suite</td>
       <td></td>
-      <td>{'30s', '15m'}</td>
+      <td>{'15m', '30s'}</td>
       <td><a href="https://bitbucket.org/arahat/cfd-test-problem-suite">https://bitbucket.org/arahat/cfd-test-problem-suite</a></td>
       <td>Expensive real-world CFD-based test problems</td>
       <td></td>
@@ -1891,7 +1891,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_cre</td>
       <td>CRE</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>6-14</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -1977,7 +1977,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>>=3</td>
       <td>1</td>
       <td></td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td></td>
@@ -2178,7 +2178,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_expobench</td>
       <td>EXPObench</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>continuous | integer | categorical</td>
       <td>30-405</td>
       <td>1</td>
       <td>noisy</td>
@@ -2204,7 +2204,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>10-135</td>
       <td>EXPObench</td>
       <td>Python</td>
-      <td>{'2 seconds', '80 seconds'}</td>
+      <td>{'80 seconds', '2 seconds'}</td>
       <td><a href="https://github.com/AlgTUDelft/ExpensiveOptimBenchmark">https://github.com/AlgTUDelft/ExpensiveOptimBenchmark</a></td>
       <td>EXPensive Optimization benchmark library (wind farm layout, gas filter design, pipe shape, hyperparameter tuning, hospital simulation)</td>
       <td></td>
@@ -2245,7 +2245,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>coco-gbea</td>
       <td></td>
-      <td>{'34 seconds', '5 seconds'}</td>
+      <td>{'5 seconds', '34 seconds'}</td>
       <td><a href="https://github.com/ttusar/coco-gbea">https://github.com/ttusar/coco-gbea</a></td>
       <td>Game-Benchmark for Evolutionary Algorithms (COCO fork)</td>
       <td></td>
@@ -2325,11 +2325,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHGNBG | GNBG-II</td>
+      <td>GNBG-II | IOHGNBG</td>
       <td></td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a> | <a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a></td>
-      <td>IOHprofiler version of GNBG | Generalized Numerical Benchmark Generator version 2</td>
+      <td><a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a> | <a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a></td>
+      <td>Generalized Numerical Benchmark Generator version 2 | IOHprofiler version of GNBG</td>
       <td></td>
       <td></td>
       <td></td>
@@ -2696,7 +2696,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>MECHBench</td>
       <td>Python</td>
-      <td>{'1 minute', '7 minutes'}</td>
+      <td>{'7 minutes', '1 minute'}</td>
       <td><a href="https://github.com/BayesOptApp/MECHBench">https://github.com/BayesOptApp/MECHBench</a></td>
       <td>Structural mechanics design optimization benchmark</td>
       <td></td>
@@ -2875,7 +2875,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_modact</td>
       <td>MODAct</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>40</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -2899,11 +2899,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>20</td>
       <td>20</td>
-      <td>modact | pymoo</td>
+      <td>pymoo | modact</td>
       <td>Python</td>
       <td>{'20ms'}</td>
-      <td><a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a> | <a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a></td>
-      <td>EPFL-LAMD modact package | Multi-objective optimization in Python</td>
+      <td><a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a> | <a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a></td>
+      <td>Multi-objective optimization in Python | EPFL-LAMD modact package</td>
       <td></td>
       <td></td>
       <td></td>
@@ -3039,7 +3039,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_re</td>
       <td>RE</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>4-14</td>
       <td>[2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td></td>
@@ -3080,7 +3080,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_rwmvop</td>
       <td>RWMVOP</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>integer | categorical | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -132,7 +132,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>>=2</td>
       <td>2</td>
       <td></td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td></td>
@@ -214,7 +214,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>26</td>
       <td>1</td>
       <td>noisy</td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=14</td>
       <td></td>
       <td>noisy</td>
@@ -292,7 +292,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>fn_gasoline</td>
       <td>Gasoline direct injection engine design</td>
       <td>Problem</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>14</td>
       <td>2</td>
       <td>multi-fidelity</td>
@@ -661,7 +661,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>gen_ealain</td>
       <td>Ealain</td>
       <td>Generator</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>[1, 10, 2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td>dynamic | multi-fidelity</td>
@@ -1030,7 +1030,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>gen_randoptgen</td>
       <td>RandOptGen</td>
       <td>Generator</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>[1, 10, 2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td></td>
@@ -1194,7 +1194,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_amvop</td>
       <td>AMVOP</td>
       <td>Suite</td>
-      <td>categorical | continuous | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1710,11 +1710,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHexperimenter | CEC2013 reference code</td>
+      <td>CEC2013 reference code | IOHexperimenter</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a></td>
-      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
+      <td><a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
+      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1833,11 +1833,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHexperimenter | CEC2022 reference code</td>
+      <td>CEC2022 reference code | IOHexperimenter</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/2022-SO-BO">https://github.com/P-N-Suganthan/2022-SO-BO</a></td>
-      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
+      <td><a href="https://github.com/P-N-Suganthan/2022-SO-BO">https://github.com/P-N-Suganthan/2022-SO-BO</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
+      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1876,7 +1876,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>CFD test problem suite</td>
       <td></td>
-      <td>{'15m', '30s'}</td>
+      <td>{'30s', '15m'}</td>
       <td><a href="https://bitbucket.org/arahat/cfd-test-problem-suite">https://bitbucket.org/arahat/cfd-test-problem-suite</a></td>
       <td>Expensive real-world CFD-based test problems</td>
       <td></td>
@@ -1932,7 +1932,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_cuter</td>
       <td>CUTEr</td>
       <td>Suite</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1973,7 +1973,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_cutest</td>
       <td>CUTEst</td>
       <td>Suite</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -2178,11 +2178,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_expobench</td>
       <td>EXPObench</td>
       <td>Suite</td>
-      <td>continuous | categorical | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>30-405</td>
       <td>1</td>
       <td>noisy</td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td>["observational", "real-life"]</td>
@@ -2875,7 +2875,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_modact</td>
       <td>MODAct</td>
       <td>Suite</td>
-      <td>continuous | integer</td>
+      <td>integer | continuous</td>
       <td>40</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -2899,11 +2899,11 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td></td>
       <td>20</td>
       <td>20</td>
-      <td>pymoo | modact</td>
+      <td>modact | pymoo</td>
       <td>Python</td>
       <td>{'20ms'}</td>
-      <td><a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a> | <a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a></td>
-      <td>Multi-objective optimization in Python | EPFL-LAMD modact package</td>
+      <td><a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a> | <a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a></td>
+      <td>EPFL-LAMD modact package | Multi-objective optimization in Python</td>
       <td></td>
       <td></td>
       <td></td>
@@ -3080,7 +3080,7 @@ Submit problems and corrections on <a target="_blank" href="https://github.com/O
       <td>suite_rwmvop</td>
       <td>RWMVOP</td>
       <td>Suite</td>
-      <td>categorical | continuous | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>

--- a/docs/problems.html
+++ b/docs/problems.html
@@ -106,7 +106,7 @@
       <td>>=2</td>
       <td>2</td>
       <td></td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td></td>
@@ -188,7 +188,7 @@
       <td>26</td>
       <td>1</td>
       <td>noisy</td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=14</td>
       <td></td>
       <td>noisy</td>
@@ -266,7 +266,7 @@
       <td>fn_gasoline</td>
       <td>Gasoline direct injection engine design</td>
       <td>Problem</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>14</td>
       <td>2</td>
       <td>multi-fidelity</td>
@@ -635,7 +635,7 @@
       <td>gen_ealain</td>
       <td>Ealain</td>
       <td>Generator</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>[1, 10, 2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td>dynamic | multi-fidelity</td>
@@ -1004,7 +1004,7 @@
       <td>gen_randoptgen</td>
       <td>RandOptGen</td>
       <td>Generator</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>[1, 10, 2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td></td>
@@ -1168,7 +1168,7 @@
       <td>suite_amvop</td>
       <td>AMVOP</td>
       <td>Suite</td>
-      <td>categorical | continuous | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1684,11 +1684,11 @@
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHexperimenter | CEC2013 reference code</td>
+      <td>CEC2013 reference code | IOHexperimenter</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a></td>
-      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
+      <td><a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
+      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1807,11 +1807,11 @@
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHexperimenter | CEC2022 reference code</td>
+      <td>CEC2022 reference code | IOHexperimenter</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/2022-SO-BO">https://github.com/P-N-Suganthan/2022-SO-BO</a></td>
-      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
+      <td><a href="https://github.com/P-N-Suganthan/2022-SO-BO">https://github.com/P-N-Suganthan/2022-SO-BO</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
+      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1850,7 +1850,7 @@
       <td></td>
       <td>CFD test problem suite</td>
       <td></td>
-      <td>{'15m', '30s'}</td>
+      <td>{'30s', '15m'}</td>
       <td><a href="https://bitbucket.org/arahat/cfd-test-problem-suite">https://bitbucket.org/arahat/cfd-test-problem-suite</a></td>
       <td>Expensive real-world CFD-based test problems</td>
       <td></td>
@@ -1906,7 +1906,7 @@
       <td>suite_cuter</td>
       <td>CUTEr</td>
       <td>Suite</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1947,7 +1947,7 @@
       <td>suite_cutest</td>
       <td>CUTEst</td>
       <td>Suite</td>
-      <td>binary | continuous | integer</td>
+      <td>integer | binary | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -2152,11 +2152,11 @@
       <td>suite_expobench</td>
       <td>EXPObench</td>
       <td>Suite</td>
-      <td>continuous | categorical | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>30-405</td>
       <td>1</td>
       <td>noisy</td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td>["observational", "real-life"]</td>
@@ -2849,7 +2849,7 @@
       <td>suite_modact</td>
       <td>MODAct</td>
       <td>Suite</td>
-      <td>continuous | integer</td>
+      <td>integer | continuous</td>
       <td>40</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -2873,11 +2873,11 @@
       <td></td>
       <td>20</td>
       <td>20</td>
-      <td>pymoo | modact</td>
+      <td>modact | pymoo</td>
       <td>Python</td>
       <td>{'20ms'}</td>
-      <td><a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a> | <a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a></td>
-      <td>Multi-objective optimization in Python | EPFL-LAMD modact package</td>
+      <td><a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a> | <a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a></td>
+      <td>EPFL-LAMD modact package | Multi-objective optimization in Python</td>
       <td></td>
       <td></td>
       <td></td>
@@ -3054,7 +3054,7 @@
       <td>suite_rwmvop</td>
       <td>RWMVOP</td>
       <td>Suite</td>
-      <td>categorical | continuous | integer</td>
+      <td>integer | continuous | categorical</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>

--- a/docs/problems.html
+++ b/docs/problems.html
@@ -128,7 +128,7 @@
       <td></td>
       <td>BSO-toolbox</td>
       <td>C++</td>
-      <td>{'40 seconds', '1 second'}</td>
+      <td>{'1 second', '40 seconds'}</td>
       <td><a href="https://github.com/TUe-excellent-buildings/BSO-toolbox">https://github.com/TUe-excellent-buildings/BSO-toolbox</a></td>
       <td>Building Spatial Design toolbox (TU/e)</td>
       <td></td>
@@ -188,7 +188,7 @@
       <td>26</td>
       <td>1</td>
       <td>noisy</td>
-      <td>box | unknown</td>
+      <td>unknown | box</td>
       <td>>=14</td>
       <td></td>
       <td>noisy</td>
@@ -741,11 +741,11 @@
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHGNBG | GNBG-II</td>
+      <td>GNBG-II | IOHGNBG</td>
       <td></td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a> | <a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a></td>
-      <td>IOHprofiler version of GNBG | Generalized Numerical Benchmark Generator version 2</td>
+      <td><a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a> | <a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a></td>
+      <td>Generalized Numerical Benchmark Generator version 2 | IOHprofiler version of GNBG</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1168,7 +1168,7 @@
       <td>suite_amvop</td>
       <td>AMVOP</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>integer | categorical | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>
@@ -1291,7 +1291,7 @@
       <td>suite_bbob_biobj_mixint</td>
       <td>BBOB-biobj-mixint</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>10-320</td>
       <td>2</td>
       <td></td>
@@ -1414,7 +1414,7 @@
       <td>suite_bbob_mixint</td>
       <td>BBOB-mixint</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>10-320</td>
       <td>1</td>
       <td></td>
@@ -1684,11 +1684,11 @@
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>CEC2013 reference code | IOHexperimenter</td>
+      <td>IOHexperimenter | CEC2013 reference code</td>
       <td>C++/Python</td>
       <td></td>
-      <td><a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a> | <a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a></td>
-      <td>Suganthan's reference implementation | IOHprofiler experimenter framework</td>
+      <td><a href="https://github.com/IOHprofiler/IOHexperimenter">https://github.com/IOHprofiler/IOHexperimenter</a> | <a href="https://github.com/P-N-Suganthan/CEC2013">https://github.com/P-N-Suganthan/CEC2013</a></td>
+      <td>IOHprofiler experimenter framework | Suganthan's reference implementation</td>
       <td></td>
       <td></td>
       <td></td>
@@ -1850,7 +1850,7 @@
       <td></td>
       <td>CFD test problem suite</td>
       <td></td>
-      <td>{'30s', '15m'}</td>
+      <td>{'15m', '30s'}</td>
       <td><a href="https://bitbucket.org/arahat/cfd-test-problem-suite">https://bitbucket.org/arahat/cfd-test-problem-suite</a></td>
       <td>Expensive real-world CFD-based test problems</td>
       <td></td>
@@ -1865,7 +1865,7 @@
       <td>suite_cre</td>
       <td>CRE</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>6-14</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -1951,7 +1951,7 @@
       <td>>=3</td>
       <td>1</td>
       <td></td>
-      <td>unknown | box</td>
+      <td>box | unknown</td>
       <td>>=2</td>
       <td></td>
       <td></td>
@@ -2152,7 +2152,7 @@
       <td>suite_expobench</td>
       <td>EXPObench</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>continuous | integer | categorical</td>
       <td>30-405</td>
       <td>1</td>
       <td>noisy</td>
@@ -2178,7 +2178,7 @@
       <td>10-135</td>
       <td>EXPObench</td>
       <td>Python</td>
-      <td>{'2 seconds', '80 seconds'}</td>
+      <td>{'80 seconds', '2 seconds'}</td>
       <td><a href="https://github.com/AlgTUDelft/ExpensiveOptimBenchmark">https://github.com/AlgTUDelft/ExpensiveOptimBenchmark</a></td>
       <td>EXPensive Optimization benchmark library (wind farm layout, gas filter design, pipe shape, hyperparameter tuning, hospital simulation)</td>
       <td></td>
@@ -2219,7 +2219,7 @@
       <td></td>
       <td>coco-gbea</td>
       <td></td>
-      <td>{'34 seconds', '5 seconds'}</td>
+      <td>{'5 seconds', '34 seconds'}</td>
       <td><a href="https://github.com/ttusar/coco-gbea">https://github.com/ttusar/coco-gbea</a></td>
       <td>Game-Benchmark for Evolutionary Algorithms (COCO fork)</td>
       <td></td>
@@ -2299,11 +2299,11 @@
       <td></td>
       <td>>=1</td>
       <td></td>
-      <td>IOHGNBG | GNBG-II</td>
+      <td>GNBG-II | IOHGNBG</td>
       <td></td>
       <td></td>
-      <td><a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a> | <a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a></td>
-      <td>IOHprofiler version of GNBG | Generalized Numerical Benchmark Generator version 2</td>
+      <td><a href="https://github.com/rohitsalgotra/GNBG-II">https://github.com/rohitsalgotra/GNBG-II</a> | <a href="https://github.com/IOHprofiler/IOHGNBG">https://github.com/IOHprofiler/IOHGNBG</a></td>
+      <td>Generalized Numerical Benchmark Generator version 2 | IOHprofiler version of GNBG</td>
       <td></td>
       <td></td>
       <td></td>
@@ -2670,7 +2670,7 @@
       <td></td>
       <td>MECHBench</td>
       <td>Python</td>
-      <td>{'1 minute', '7 minutes'}</td>
+      <td>{'7 minutes', '1 minute'}</td>
       <td><a href="https://github.com/BayesOptApp/MECHBench">https://github.com/BayesOptApp/MECHBench</a></td>
       <td>Structural mechanics design optimization benchmark</td>
       <td></td>
@@ -2849,7 +2849,7 @@
       <td>suite_modact</td>
       <td>MODAct</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>40</td>
       <td>[2, 3, 4, 5]</td>
       <td></td>
@@ -2873,11 +2873,11 @@
       <td></td>
       <td>20</td>
       <td>20</td>
-      <td>modact | pymoo</td>
+      <td>pymoo | modact</td>
       <td>Python</td>
       <td>{'20ms'}</td>
-      <td><a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a> | <a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a></td>
-      <td>EPFL-LAMD modact package | Multi-objective optimization in Python</td>
+      <td><a href="https://github.com/anyoptimization/pymoo">https://github.com/anyoptimization/pymoo</a> | <a href="https://github.com/epfl-lamd/modact">https://github.com/epfl-lamd/modact</a></td>
+      <td>Multi-objective optimization in Python | EPFL-LAMD modact package</td>
       <td></td>
       <td></td>
       <td></td>
@@ -3013,7 +3013,7 @@
       <td>suite_re</td>
       <td>RE</td>
       <td>Suite</td>
-      <td>integer | continuous</td>
+      <td>continuous | integer</td>
       <td>4-14</td>
       <td>[2, 3, 4, 5, 6, 7, 8, 9]</td>
       <td></td>
@@ -3054,7 +3054,7 @@
       <td>suite_rwmvop</td>
       <td>RWMVOP</td>
       <td>Suite</td>
-      <td>integer | continuous | categorical</td>
+      <td>integer | categorical | continuous</td>
       <td>>=3</td>
       <td>1</td>
       <td></td>

--- a/problems.yaml
+++ b/problems.yaml
@@ -44,8 +44,8 @@ fn_building_spatial:
     evaluations.
   dynamic_type: null
   evaluation_time:
-  - 40 seconds
   - 1 second
+  - 40 seconds
   fidelity_levels: null
   implementations:
   - impl_bso_toolbox
@@ -70,11 +70,11 @@ fn_building_spatial:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 fn_convex_dtlz2:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -120,10 +120,6 @@ fn_emdo:
   code_examples: null
   constraints:
   - equality: null
-    hard: yes
-    number: null
-    type: box
-  - equality: null
     hard: some
     number: null
     type: unknown
@@ -131,6 +127,10 @@ fn_emdo:
     hard: yes
     number: 12
     type: unknown
+  - equality: null
+    hard: yes
+    number: null
+    type: box
   description: "# Goal\nFind a design of a synchronous electric motor for power steering
     systems that minimizes costs and satisfies all constraints.\n\n# Motivation\n\
     Challenging to find good solutions in a limited time.\n\n# Key Challenges\n* Time-consuming
@@ -205,8 +205,8 @@ fn_fleetopt:
   type: problem
   variables:
   - dim:
-    - 13208
     - 54
+    - 13208
     type: integer
 fn_gasoline:
   allows_partial_evaluation: null
@@ -282,11 +282,11 @@ fn_invdeceptive_deceptive_rotell:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 fn_inverted_dtlz1:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -398,11 +398,11 @@ fn_onemax_sphere_deceptive_rotell:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 fn_onemax_sphere_zeromax_sphere:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -434,11 +434,11 @@ fn_onemax_sphere_zeromax_sphere:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 fn_radar_waveform:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -598,11 +598,11 @@ gen_ealain:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
   - dim:
       max: null
       min: 1
@@ -929,11 +929,11 @@ gen_randoptgen:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
   - dim:
       max: null
       min: 1
@@ -1082,8 +1082,8 @@ impl_bonobench:
 impl_bso_toolbox:
   description: Building Spatial Design toolbox (TU/e)
   evaluation_time:
-  - 40 seconds
   - 1 second
+  - 40 seconds
   language: C++
   links:
   - type: repository
@@ -1221,8 +1221,8 @@ impl_gasoline:
 impl_gbea:
   description: Game-Benchmark for Evolutionary Algorithms (COCO fork)
   evaluation_time:
-  - 5 seconds
   - 34 seconds
+  - 5 seconds
   language: null
   links:
   - type: repository
@@ -1306,8 +1306,8 @@ impl_ma_bbob:
 impl_mechbench:
   description: Structural mechanics design optimization benchmark
   evaluation_time:
-  - 7 minutes
   - 1 minute
+  - 7 minutes
   language: Python
   links:
   - type: repository
@@ -1518,15 +1518,15 @@ suite_amvop:
   - dim:
       max: null
       min: 1
+    type: categorical
+  - dim:
+      max: null
+      min: 1
     type: continuous
   - dim:
       max: null
       min: 1
     type: integer
-  - dim:
-      max: null
-      min: 1
-    type: categorical
 suite_bbob:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -1625,11 +1625,11 @@ suite_bbob_biobj_mixint:
   - dim:
       max: 160
       min: 5
-    type: integer
+    type: continuous
   - dim:
       max: 160
       min: 5
-    type: continuous
+    type: integer
 suite_bbob_constrained:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -1732,11 +1732,11 @@ suite_bbob_mixint:
   - dim:
       max: 160
       min: 5
-    type: integer
+    type: continuous
   - dim:
       max: 160
       min: 5
-    type: continuous
+    type: integer
 suite_bbob_noisy:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -1946,8 +1946,8 @@ suite_cec2013:
   evaluation_time: null
   fidelity_levels: null
   implementations:
-  - impl_iohexperimenter
   - impl_cec2013
+  - impl_iohexperimenter
   long_name: null
   modality: null
   name: CEC2013
@@ -2052,8 +2052,8 @@ suite_cec2022:
   evaluation_time: null
   fidelity_levels: null
   implementations:
-  - impl_iohexperimenter
   - impl_cec2022
+  - impl_iohexperimenter
   long_name: null
   modality: null
   name: CEC2022
@@ -2196,11 +2196,11 @@ suite_cuter:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
   - dim:
       max: null
       min: 1
@@ -2211,15 +2211,15 @@ suite_cutest:
   code_examples: null
   constraints:
   - equality: null
-    hard: yes
-    number: null
-    type: box
-  - equality: null
     hard: some
     number:
       max: null
       min: 1
     type: unknown
+  - equality: null
+    hard: yes
+    number: null
+    type: box
   description: CUTEst for optimization software
   dynamic_type: null
   evaluation_time: null
@@ -2248,11 +2248,11 @@ suite_cutest:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
   - dim:
       max: null
       min: 1
@@ -2455,13 +2455,13 @@ suite_expobench:
   code_examples: null
   constraints:
   - equality: null
-    hard: yes
-    number: null
-    type: box
-  - equality: null
     hard: some
     number: null
     type: unknown
+  - equality: null
+    hard: yes
+    number: null
+    type: box
   description: Wind farm layout optimization, gas filter design, pipe shape 
     optimization, hyperparameter tuning, and hospital simulation
   dynamic_type: null
@@ -2473,8 +2473,8 @@ suite_expobench:
   modality: null
   name: EXPObench
   noise_type:
-  - real-life
   - observational
+  - real-life
   objectives:
   - 1
   problems: null
@@ -2492,15 +2492,15 @@ suite_expobench:
   - dim:
       max: 135
       min: 10
-    type: integer
-  - dim:
-      max: 135
-      min: 10
     type: categorical
   - dim:
       max: 135
       min: 10
     type: continuous
+  - dim:
+      max: 135
+      min: 10
+    type: integer
 suite_gbea:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -2703,11 +2703,11 @@ suite_l1_zdt:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 suite_l2_dtlz:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -2777,11 +2777,11 @@ suite_l2_zdt:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 suite_l3_dtlz:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -2851,11 +2851,11 @@ suite_l3_zdt:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous
 suite_maop:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -3132,9 +3132,9 @@ suite_modact:
   type: suite
   variables:
   - dim: 20
-    type: integer
-  - dim: 20
     type: continuous
+  - dim: 20
+    type: integer
 suite_morepo:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -3272,11 +3272,11 @@ suite_re:
   - dim:
       max: 7
       min: 2
-    type: integer
+    type: continuous
   - dim:
       max: 7
       min: 2
-    type: continuous
+    type: integer
 suite_rwmvop:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -3312,15 +3312,15 @@ suite_rwmvop:
   - dim:
       max: null
       min: 1
+    type: categorical
+  - dim:
+      max: null
+      min: 1
     type: continuous
   - dim:
       max: null
       min: 1
     type: integer
-  - dim:
-      max: null
-      min: 1
-    type: categorical
 suite_sbox_cost:
   allows_partial_evaluation: null
   can_evaluate_objectives_independently: null
@@ -3590,8 +3590,8 @@ suite_zdt:
   - dim:
       max: null
       min: 1
-    type: continuous
+    type: binary
   - dim:
       max: null
       min: 1
-    type: binary
+    type: continuous

--- a/src/opltools/schema.py
+++ b/src/opltools/schema.py
@@ -1,10 +1,64 @@
+import json
 from enum import Enum
 from typing import Any
 from typing_extensions import Self
-from pydantic import BaseModel, RootModel, ConfigDict, model_validator
+from pydantic import (
+    BaseModel,
+    RootModel,
+    ConfigDict,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+    model_validator,
+)
 
 from .yesnosome import YesNoSome
 from .utils import ValueRange, union_range
+
+
+def _sort_key(item: Any) -> Any:
+    """Stable, total-order sort key for an already-serialized set member.
+
+    Scalars (str, int, float, bool) sort by their natural ordering, so e.g.
+    `{2, 10}` sorts numerically rather than as the strings "10" < "2". Dicts
+    and lists (serialized nested models) have no natural ordering, so those
+    fall back to a canonical JSON string.
+    """
+    if isinstance(item, (dict, list)):
+        return json.dumps(item, sort_keys=True, default=str)
+    return item
+
+
+class _CanonicalMixin:
+    """Serialize any `set`-valued field as a sorted list.
+
+    `set` iteration order depends on Python's hash randomization, so two
+    otherwise-identical models can serialize to different YAML on every run
+    unless we impose a fixed order. Rather than hand-listing every `set`
+    field on every model, this inspects each model's actual field values at
+    serialization time and sorts whichever ones happen to be a `set` -
+    including nested models' own sets (each canonicalizes itself the same
+    way) and any `extra="allow"` fields.
+    """
+
+    @model_serializer(mode="wrap")
+    def _canonicalize(self, handler: SerializerFunctionWrapHandler) -> Any:
+        data = handler(self)
+        values = dict(self.__dict__)
+        extra = getattr(self, "__pydantic_extra__", None)
+        if extra:
+            values.update(extra)
+        for name, value in values.items():
+            if isinstance(value, set) and name in data:
+                data[name] = sorted(data[name], key=_sort_key)
+        return data
+
+
+class CanonicalModel(_CanonicalMixin, BaseModel):
+    pass
+
+
+class CanonicalRootModel(_CanonicalMixin, RootModel):
+    pass
 
 
 class OPLType(Enum):
@@ -14,7 +68,7 @@ class OPLType(Enum):
     implementation = "implementation"
 
 
-class Link(BaseModel):
+class Link(CanonicalModel):
     type: str | None = None
     url: str
 
@@ -22,12 +76,12 @@ class Link(BaseModel):
         return hash(self.type) + hash(self.url)
 
 
-class Thing(BaseModel):
+class Thing(CanonicalModel):
     type: OPLType
     model_config = ConfigDict(extra="allow")
 
 
-class Objectives(RootModel):
+class Objectives(CanonicalRootModel):
     root: int | set[int] | ValueRange = 0
 
     def union(self, other: Self) -> Self:
@@ -43,7 +97,7 @@ class VariableType(Enum):
     unknown = "unknown"
 
 
-class Variable(BaseModel):
+class Variable(CanonicalModel):
     type: VariableType = VariableType.unknown
     dim: int | set[int] | ValueRange | None = 0
 
@@ -62,7 +116,7 @@ class ConstraintType(Enum):
     unknown = "unknown"
 
 
-class Constraint(BaseModel):
+class Constraint(CanonicalModel):
     type: ConstraintType = ConstraintType.unknown
     hard: YesNoSome | None = None
     equality: YesNoSome | None = None
@@ -73,7 +127,7 @@ class Constraint(BaseModel):
         return hash((self.type, self.hard, self.equality, number))
 
 
-class Reference(BaseModel):
+class Reference(CanonicalModel):
     title: str | None = None
     authors: list[str] | None = None
     link: Link | None = None
@@ -136,7 +190,7 @@ class Generator(ProblemLike):
     type: OPLType = OPLType.generator
 
 
-class Library(RootModel):
+class Library(CanonicalRootModel):
     root: dict[str, Problem | Generator | Suite | Implementation] = {}
 
     def _check_id_references(self, ids, type: OPLType) -> None:


### PR DESCRIPTION
pydantic-yaml serializes model fields via model_dump_json() but set iteration  is order depends on hash randomization, which is randomized per interpreter process, so `to_yaml_str()` produced a different ordering of these fields on every run even when the underlying data was unchanged.

Add a `_CanonicalMixin` used by new `CanonicalModel`/`CanonicalRootModel` base classes in schema.py. Each defines a single model_serializer(mode="wrap") that inspects a model's actual field values at dump time and sorts any that are a `set` into a list.

Fixes #202